### PR TITLE
👍 fix ac-library path

### DIFF
--- a/bin/expander
+++ b/bin/expander
@@ -2,7 +2,7 @@
 
 BASE_DIR=$(dirname $0)
 
-AC_DIR="$(cd -- "${BASE_DIR}/../../ac-library" && pwd)" || exit $?
+AC_DIR="$(cd -- "${BASE_DIR}/../ac-library" && pwd)" || exit $?
 BCPL_DIR="$(cd -- "${BASE_DIR}/../../byplayer_cp_library/include" && pwd)" || exit $?
 
 CPLUS_INCLUDE_PATH=${AC_DIR}:${BCPL_DIR} python $BASE_DIR/expander.py $*


### PR DESCRIPTION
I change ac-library path because I use ac-library as submodule in this repository.