### PR TITLE
Release version 0.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(byplayer_cp_library VERSION 1.0.0 LANGUAGES CXX)
+project(byplayer_cp_library VERSION 0.5.0 LANGUAGES CXX)
 
 # Set default C++ standard if not specified
 if(NOT CMAKE_CXX_STANDARD)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,18 @@
 # change log(変更履歴)
 
+## 0.5.0 / 2024-09-27
+
+- Migrate build system from Makefile to CMake
+- ビルドシステムをMakefileからCMakeに移行
+- Add support for multiple compilers (clang++, g++) and C++ standards (C++17/20/23)
+- 複数のコンパイラ（clang++、g++）とC++標準（C++17/20/23）のサポートを追加
+- Improve dependency management with automatic GoogleTest fetching
+- GoogleTestの自動取得による依存関係管理の改善
+- Add CMakePresets.json for convenient build configurations
+- 便利なビルド設定のためのCMakePresets.jsonを追加
+- Update CI/CD pipeline to use CMake
+- CI/CDパイプラインをCMake使用に更新
+
 ## 0.4.0 / 2024-09-26
 
 - support origname option at expander.py


### PR DESCRIPTION
## Summary

This PR updates the project version to 0.5.0 and changelog to document the CMake migration.

## Changes

- Update project version from 1.0.0 to 0.5.0 in CMakeLists.txt
- Add changelog entry for version 0.5.0 documenting the CMake build system migration

## Related

This version bump follows the successful migration to CMake build system completed in PR #26.

The changelog entry documents:
- Migration from Makefile to CMake
- Support for multiple compilers (clang++/g++) and C++ standards (17/20/23)
- Automatic dependency management with GoogleTest
- CMakePresets.json for convenient build configurations
- Updated CI/CD pipeline